### PR TITLE
saveDefaultConfig Function to fix Warning

### DIFF
--- a/src/main/java/me/yamakaja/commanditems/CommandItems.java
+++ b/src/main/java/me/yamakaja/commanditems/CommandItems.java
@@ -26,7 +26,7 @@ public class CommandItems extends JavaPlugin {
     public void onEnable() {
         new Metrics(this);
 
-        this.saveResource("config.yml", System.getProperty("me.yamakaja.debug") != null);
+        this.saveDefaultConfig();
 
         this.configManager = new ConfigManager(this);
         configManager.parse();


### PR DESCRIPTION
There is a warning that shows up when you first add the plugin, then restart you server after it has already created the config file. The plugin tries to add a config file there even though there is already one. It causes a warning. This function only adds a config file if there isn't already one there.